### PR TITLE
Fix/dummy ingredients

### DIFF
--- a/CookNook.csproj
+++ b/CookNook.csproj
@@ -79,6 +79,9 @@
 	  <Compile Update="Cookbook.xaml.cs">
 	    <DependentUpon>Cookbook.xaml</DependentUpon>
 	  </Compile>
+	  <Compile Update="IngredientSelectionPage.xaml.cs">
+	    <DependentUpon>IngredientSelectionPage.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="SearchPage.xaml.cs">
 	    <DependentUpon>SearchPage.xaml</DependentUpon>
 	  </Compile>
@@ -101,6 +104,9 @@
 
 	<ItemGroup>
 	  <MauiXaml Update="Cookbook.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="IngredientSelectionPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="SearchPage.xaml">

--- a/Cookbook.xaml
+++ b/Cookbook.xaml
@@ -1,6 +1,6 @@
 ﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:converter="clr-namespace:CookNook.Model"
+             xmlns:XmlHelpers="clr-namespace:CookNook.XMLHelpers"
              x:Class="CookNook.Cookbook"
              Title="{Binding PageTitle}"
              NavigationPage.HasBackButton="False"
@@ -9,7 +9,7 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <converter:ByteToImageConverter x:Key="ByteToImageConverter"/>
+            <XmlHelpers:ByteToImageConverter x:Key="ByteToImageConverter"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/Feed.xaml
+++ b/Feed.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:converter="clr-namespace:CookNook.Model"
+             xmlns:XmlHelpers="clr-namespace:CookNook.XMLHelpers"
              x:Class="CookNook.Feed"
              NavigationPage.HasBackButton="False"
              Title="Feed">
@@ -24,7 +24,7 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <converter:ByteToImageConverter x:Key="ByteToImageConverter"/>
+            <XmlHelpers:ByteToImageConverter x:Key="ByteToImageConverter"/>
         </ResourceDictionary>
     </ContentPage.Resources>
     

--- a/Feed.xaml
+++ b/Feed.xaml
@@ -77,7 +77,7 @@
 
         </Grid>
 
-        <CollectionView x:Name="recipesCollectionView" Margin="10" Grid.Row="3">
+        <CollectionView x:Name="RecipesCollectionView" Margin="10" Grid.Row="3">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Frame BackgroundColor="LightGray" Padding="10" CornerRadius="10" Margin="5">

--- a/Feed.xaml.cs
+++ b/Feed.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using CookNook.Model;
 using System.Diagnostics;
 using CookNook.Services;
@@ -6,6 +7,14 @@ namespace CookNook;
 
 public partial class Feed : ContentPage
 {
+    private ObservableCollection<Recipe> recipes;
+
+    public ObservableCollection<Recipe> Recipes
+    {
+        get { return recipes; }
+        set { recipes = value; }
+    }
+
     private IRecipeLogic recipeLogic;
     private User user;
     public Feed(User inUser)
@@ -14,14 +23,15 @@ public partial class Feed : ContentPage
         //recipeLogic = new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase()));
         recipeLogic = MauiProgram.ServiceProvider.GetService<IRecipeLogic>();
         user = inUser;
-        loadRecipes();
+        PopulateFeedWithRecipes();
     }
+
     public Feed()
     {
         InitializeComponent();
         recipeLogic = MauiProgram.ServiceProvider.GetService<IRecipeLogic>();
         user = UserViewModel.Instance.AppUser;
-        loadRecipes();
+        PopulateFeedWithRecipes();
     }
     
     public Feed(IRecipeLogic recipeLogic)
@@ -29,7 +39,7 @@ public partial class Feed : ContentPage
         this.recipeLogic = recipeLogic;
     }
 
-    private void loadRecipes()
+    private void PopulateFeedWithRecipes()
     {
         var recipes = recipeLogic.FeedRecipes();
         // making sure they have proper data

--- a/Feed.xaml.cs
+++ b/Feed.xaml.cs
@@ -11,14 +11,15 @@ public partial class Feed : ContentPage
     public Feed(User inUser)
     {
         InitializeComponent();
-        recipeLogic = new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase()));
+        //recipeLogic = new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase()));
+        recipeLogic = MauiProgram.ServiceProvider.GetService<IRecipeLogic>();
         user = inUser;
         loadRecipes();
     }
     public Feed()
     {
         InitializeComponent();
-        recipeLogic = new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase()));
+        recipeLogic = MauiProgram.ServiceProvider.GetService<IRecipeLogic>();
         user = UserViewModel.Instance.AppUser;
         loadRecipes();
     }
@@ -30,7 +31,9 @@ public partial class Feed : ContentPage
 
     private void loadRecipes()
     {
-        recipesCollectionView.ItemsSource = recipeLogic.FeedRecipes();
+        var recipes = recipeLogic.FeedRecipes();
+        // making sure they have proper data
+        RecipesCollectionView.ItemsSource = recipes;
     }
 
     public async void UserProfileClicked(object sender, EventArgs e)

--- a/Feed.xaml.cs
+++ b/Feed.xaml.cs
@@ -41,7 +41,7 @@ public partial class Feed : ContentPage
 
     private void PopulateFeedWithRecipes()
     {
-        var recipes = recipeLogic.FeedRecipes();
+        Recipes = recipeLogic.FeedRecipes();
         // making sure they have proper data
         RecipesCollectionView.ItemsSource = recipes;
     }

--- a/Model/CourseType.cs
+++ b/Model/CourseType.cs
@@ -25,6 +25,9 @@ namespace CookNook.Model
         public static readonly CourseType Breakfast = new CourseType("Breakfast");
         public static readonly CourseType Lunch = new CourseType("Lunch");
         public static readonly CourseType Dinner = new CourseType("Dinner");
+        public static readonly CourseType Brunch= new CourseType("Brunch");
+        public static readonly CourseType Other = new CourseType("Other");
+        //public static readonly CourseType = new CourseType("");
 
         /// <summary>
         /// Returns the name of a coursetype, e.g. "Lunch"
@@ -38,6 +41,12 @@ namespace CookNook.Model
             _CourseTypes.Add(this);
         }
 
+        /// <summary>
+        /// Tries to resolve a CourseType object from a string
+        /// </summary>
+        /// <param name="toParse"></param>
+        /// <returns></returns>
+        /// <exception cref="FormatException"></exception>
         public static CourseType Parse(string toParse)
         {
             foreach(CourseType courseType in _CourseTypes)
@@ -48,6 +57,11 @@ namespace CookNook.Model
             throw new FormatException("Invalid CourseType!");
         }
 
+        /// <summary>
+        /// Returns the name of the course type, since the user has no other properties they 
+        /// should need to see.
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
             return this.Name;

--- a/Model/IngredientLogic.cs
+++ b/Model/IngredientLogic.cs
@@ -52,7 +52,7 @@ public class IngredientLogic : IIngredientLogic
         // empty name
         if (string.IsNullOrEmpty(name))
             return IngredientAdditionError.DBAdditionError;
-        
+
         // name too long
         if (name.Length > MAX_INGREDIENT_NAME_LENGTH)
         {
@@ -96,30 +96,30 @@ public class IngredientLogic : IIngredientLogic
     /// <param name="unit"></param>
     /// <param name="quantity"></param>
     /// <returns></returns>
-    //public IngredientAdditionError CreateIngredientForRecipe(Int64 recipeId, string name, string? unit, string quantity)
-    //{
-    //    // sanity checks
-    //    //var isSaneOperation = PerformSanityChecks(name);
-    //    // only the empty sanity check is needed here, so we'll hard-code it:
-    //    if (string.IsNullOrEmpty(name))
-    //    {
-    //        Debug.Write($"Invalid ingredient name {name} !");
-    //        return IngredientAdditionError.DBAdditionError;
-    //    }
+    public IngredientAdditionError CreateIngredientForRecipe(Int64 recipeId, string name, string? unit, string quantity)
+    {
+        // sanity checks
+        //var isSaneOperation = PerformSanityChecks(name);
+        // only the empty sanity check is needed here, so we'll hard-code it:
+        if (string.IsNullOrEmpty(name))
+        {
+            Debug.Write($"Invalid ingredient name {name} !");
+            return IngredientAdditionError.DBAdditionError;
+        }
 
-    //    if (string.isNullOrEmpty(quantity))
-    //    {
-    //        // if there was a problem, we'll return the error directly
-    //        Debug.Write($"Error creating ingredient { name } on recipe { recipeId }!");
-    //        return isSaneOperation;
-    //    }
+        if (string.IsNullOrEmpty(quantity))
+        {
+            // if there was a problem, we'll return the error directly
+            Debug.Write($"Error creating ingredient {name} on recipe {recipeId}!");
+            return IngredientAdditionError.BadParameters;
+        }
 
-    //    // first, we'll need to make sure the ingredient exists
-    //    var ingredient = ingredientDatabase.GetIngredientByName(name);
+        // first, we'll need to make sure the ingredient exists
+        var ingredient = ingredientDatabase.GetIngredientByName(name);
 
-    //    // if we get here, we know the ingredient doesn't exist, so we can create it
-    //    return ingredientDatabase.AddIngredientToRecipe(recipeId);
-    //}
+        // if we get here, we know the ingredient doesn't exist, so we can create it
+        return ingredientDatabase.AddIngredientToRecipe(recipeId, ingredient.IngredientId);
+    }
 
     /// <summary>
     /// Updates an ingredient's name
@@ -202,4 +202,15 @@ public class IngredientLogic : IIngredientLogic
     {
         return ingredientDatabase.GetAllIngredients();
     }
+
+    ///// <summary>
+    ///// Checks if an ingredient is present in a recipe
+    ///// </summary>
+    ///// <param name="ingredient"></param>
+    ///// <param name="recipeID"></param>
+    ///// <returns></returns>
+    //public bool IsIngredientInRecipe(Ingredient ingredient, long recipeID)
+    //{
+    //    //TODO: finish this
+    //}
 }

--- a/Model/Interfaces/IIngredientDatabase.cs
+++ b/Model/Interfaces/IIngredientDatabase.cs
@@ -54,7 +54,7 @@ namespace CookNook.Model.Interfaces
         /// <param name="recipeId">Recipe's Id</param>
         /// <param name="ingredientId">Ingredient's Id</param>
         /// <returns></returns>
-        // IngredientAdditionError AddIngredientToRecipe(Int64 recipeId, Int64 ingredientId);
+        IngredientAdditionError AddIngredientToRecipe(Int64 recipeId, Int64 ingredientId);
         
         /// <summary>
         /// Updates an ingredient by its id

--- a/Model/Interfaces/IRecipeDatabase.cs
+++ b/Model/Interfaces/IRecipeDatabase.cs
@@ -19,7 +19,6 @@ namespace CookNook.Model
 
         public List<Int64> GetRecipeFollowerIds(Int64 recipeID);
 
-
         public List<Recipe> SelectAllRecipes();
         
         public List<Recipe> SelectRecipes(List<Int64> recipeList);

--- a/RecipeDetailedView.xaml
+++ b/RecipeDetailedView.xaml
@@ -149,7 +149,7 @@
                         <StackLayout>
 
                             <Label Text="Ingredients" FontSize="Large" TextColor="#ffe6a7"/>
-                            <CollectionView ItemsSource="{Binding Recipe.Ingredients}"
+                            <CollectionView ItemsSource="{Binding Ingredients}"
                                             ItemTemplate="{StaticResource IngredientTemplateSelector}">
                                 
                             </CollectionView>

--- a/RecipeDetailedView.xaml
+++ b/RecipeDetailedView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:xml-Helpers="clr-namespace:CookNook.XMLHelpers"
+             xmlns:XmlHelpers="clr-namespace:CookNook.XMLHelpers"
              x:Class="CookNook.RecipeDetailedView"
              Title="{Binding Name}"
              BackgroundColor="#202c39">
@@ -16,7 +16,7 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <xml-Helpers:ByteToImageConverter x:Key="ByteToImageConverter"/>
+            <XmlHelpers:ByteToImageConverter x:Key="ByteToImageConverter"/>
 
             <!--On the DETAILED page, we want ALL the information visible, not just the name-->
             <DataTemplate x:Key="IngredientTemplate">
@@ -37,8 +37,9 @@
                 </StackLayout>
             </DataTemplate>
             <!--TODO: define template to highlight row if it clashes with user's diet prefs-->
+            
             <!--We need a way to determine on-the-fly which template to use... we have just the thing!-->
-
+            <XmlHelpers:IngredientTemplateSelector x:Key="IngredientTemplateSelector" />
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/RecipeDetailedView.xaml
+++ b/RecipeDetailedView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:xml-Helpers="clr-namespace:CookNook.Model"
+             xmlns:xml-Helpers="clr-namespace:CookNook.XMLHelpers"
              x:Class="CookNook.RecipeDetailedView"
              Title="{Binding Name}"
              BackgroundColor="#202c39">

--- a/RecipeDetailedView.xaml
+++ b/RecipeDetailedView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:converter="clr-namespace:CookNook.Model"
+             xmlns:xml-Helpers="clr-namespace:CookNook.Model"
              x:Class="CookNook.RecipeDetailedView"
              Title="{Binding Name}"
              BackgroundColor="#202c39">
@@ -16,7 +16,29 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <converter:ByteToImageConverter x:Key="ByteToImageConverter"/>
+            <xml-Helpers:ByteToImageConverter x:Key="ByteToImageConverter"/>
+
+            <!--On the DETAILED page, we want ALL the information visible, not just the name-->
+            <DataTemplate x:Key="IngredientTemplate">
+                <!--Horizontal row, paritioned out based on the fields present-->
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="{Binding Name}" FontAttributes="Bold"/>
+                    <Label Text="{Binding Quantity}" />
+                    <Label Text="{Binding Unit}" />
+                </StackLayout>
+            </DataTemplate>
+
+            <!--We'll also need one for displaying unitless ingredients-->
+            <DataTemplate x:Key="UnitlessIngredientTemplate">
+                <!--Horizontal row, split only in two, but should look nice relative to other rows-->
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="{Binding Name}" FontAttributes="Bold"/>
+                    <Label Text="{Binding Quantity}" />
+                </StackLayout>
+            </DataTemplate>
+            <!--TODO: define template to highlight row if it clashes with user's diet prefs-->
+            <!--We need a way to determine on-the-fly which template to use... we have just the thing!-->
+
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -126,8 +148,12 @@
                         <StackLayout>
 
                             <Label Text="Ingredients" FontSize="Large" TextColor="#ffe6a7"/>
-
-                            <Label Padding="15, 15, 0, 0" Text="•  Gound beef" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
+                            <CollectionView ItemsSource="{Binding Recipe.Ingredients}"
+                                            ItemTemplate="{StaticResource IngredientTemplateSelector}">
+                                
+                            </CollectionView>
+                            
+                            <!--<Label Padding="15, 15, 0, 0" Text="•  Gound beef" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
                             <Label Padding="15, 0, 0, 0" Text="•  Spaghetti" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
                             <Label Padding="15, 0, 0, 0" Text="•  Onions" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
                             <Label Padding="15, 0, 0, 0" Text="•  Garlic" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
@@ -135,7 +161,7 @@
                             <Label Padding="15, 0, 0, 0" Text="•  Pepper" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
                             <Label Padding="15, 0, 0, 0" Text="•  Paprika" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
                             <Label Padding="15, 0, 0, 0" Text="•  Cumin" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Chili Powder" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
+                            <Label Padding="15, 0, 0, 0" Text="•  Chili Powder" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>-->
 
                         </StackLayout>
 

--- a/RecipeDetailedView.xaml
+++ b/RecipeDetailedView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:XmlHelpers="clr-namespace:CookNook.XMLHelpers"
              x:Class="CookNook.RecipeDetailedView"
-             Title="{Binding Name}"
+             Title="{Binding Recipe.Name}"
              BackgroundColor="#202c39">
 
 
@@ -39,7 +39,7 @@
             <!--TODO: define template to highlight row if it clashes with user's diet prefs-->
             
             <!--We need a way to determine on-the-fly which template to use... we have just the thing!-->
-            <XmlHelpers:IngredientTemplateSelector x:Key="IngredientTemplateSelector" />
+            <!--<XmlHelpers:IngredientTemplateSelector x:Key="IngredientTemplateSelector" />-->
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -118,7 +118,7 @@
                         <Grid ColumnDefinitions="auto, *, auto">
 
                             <Label Text="{Binding Rating, StringFormat='Rating: {0}/5'}" Grid.Column="0" Grid.Row="1" HorizontalOptions="Center" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label x:Name="AuthorName" Text="{Binding Username}" Grid.Column="2" HorizontalOptions="Center" FontSize="Medium" TextColor="#ffe6a7"/>
+                            <Label x:Name="AuthorName" Text="{Binding User.Username}" Grid.Column="2" HorizontalOptions="Center" FontSize="Medium" TextColor="#ffe6a7"/>
 
                         </Grid>
 
@@ -134,7 +134,7 @@
                         <Grid ColumnDefinitions="auto, *, auto">
 
                             <Label Text="{Binding Servings, StringFormat='Serves {0}'}" Grid.Column="0" Grid.Row="1" HorizontalOptions="Center" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Text="{Binding FollowerIds.Length, StringFormat='{0} Followers'}" TextColor="#ffe6a7" Grid.Column="1" HorizontalOptions="Center"/>
+                            <!--<Label Text="{Binding FollowerIds.Length, StringFormat='{0} Followers'}" TextColor="#ffe6a7" Grid.Column="1" HorizontalOptions="Center"/>-->
 
                         </Grid>
 
@@ -150,20 +150,17 @@
 
                             <Label Text="Ingredients" FontSize="Large" TextColor="#ffe6a7"/>
                             <CollectionView ItemsSource="{Binding Ingredients}"
-                                            ItemTemplate="{StaticResource IngredientTemplateSelector}">
-                                
-                            </CollectionView>
-                            
-                            <!--<Label Padding="15, 15, 0, 0" Text="•  Gound beef" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Spaghetti" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Onions" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Garlic" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Salt" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Pepper" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Paprika" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Cumin" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>
-                            <Label Padding="15, 0, 0, 0" Text="•  Chili Powder" Grid.Column="1" Grid.Row="1" HorizontalOptions="Start" FontSize="Medium" TextColor="#ffe6a7"/>-->
+                                            ItemTemplate="{StaticResource IngredientTemplateSelector}"
+                                            Loaded="OnIngredientsLoaded">
 
+                            </CollectionView>
+                            <!--DIsplay only if no ingredients wer found, so the user understands the functionality is still working-->
+                            <Label x:Name="MissingIngredientsLabel"
+                                   Text="No ingredients were found on this recipe!"
+                                   TextColor="Red"
+                                   HorizontalOptions="CenterAndExpand"
+                                   FontSize="Medium"
+                                   IsVisible="False"></Label>
                         </StackLayout>
 
                         <!--Directions--><!--

--- a/RecipeDetailedView.xaml.cs
+++ b/RecipeDetailedView.xaml.cs
@@ -6,7 +6,15 @@ using System.Diagnostics;
 
 public partial class RecipeDetailedView : ContentPage
 {
-	private Recipe recipe;
+    private Recipe recipe;
+    
+    public Recipe Recipe
+    {
+        get { return recipe; }
+        set { recipe = value; }
+    }
+
+
     private UserLogic userLogic;
 
     public RecipeDetailedView(Recipe inRecipe, User user)
@@ -15,7 +23,8 @@ public partial class RecipeDetailedView : ContentPage
 		recipe = inRecipe;
         BindingContext = recipe;
         Debug.WriteLine(recipe.AuthorID);
-        userLogic = new UserLogic(new Model.Services.UserDatabase(), new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase())));
+        //userLogic = new UserLogic(new Model.Services.UserDatabase(), new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase())));
+        userLogic = MauiProgram.ServiceProvider.GetService<UserLogic>();
         User author = userLogic.GetUserById(recipe.AuthorID);
         
         AuthorName.BindingContext = author;

--- a/RecipeDetailedView.xaml.cs
+++ b/RecipeDetailedView.xaml.cs
@@ -1,3 +1,5 @@
+using CookNook.Model.Interfaces;
+
 namespace CookNook;
 using CookNook.Model;
 using CookNook.Services;
@@ -7,7 +9,14 @@ using System.Diagnostics;
 public partial class RecipeDetailedView : ContentPage
 {
     private Recipe recipe;
-    
+    private User user;
+
+    public User User
+    {
+        get { return user; }
+        set { user = value; }
+    }
+
     public Recipe Recipe
     {
         get { return recipe; }
@@ -15,20 +24,28 @@ public partial class RecipeDetailedView : ContentPage
     }
 
 
-    private UserLogic userLogic;
+    private IUserLogic userLogic;
 
     public RecipeDetailedView(Recipe inRecipe, User user)
 	{
 		InitializeComponent();
+        try
+        {
+
 		recipe = inRecipe;
+        //BindingContext = this;
         BindingContext = recipe;
-        Debug.WriteLine(recipe.AuthorID);
+        Debug.WriteLine($"Viewing recipe {inRecipe.ID} by {recipe.AuthorID}");
         //userLogic = new UserLogic(new Model.Services.UserDatabase(), new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase())));
-        userLogic = MauiProgram.ServiceProvider.GetService<UserLogic>();
-        User author = userLogic.GetUserById(recipe.AuthorID);
-        
-        AuthorName.BindingContext = author;
-        
+        userLogic = MauiProgram.ServiceProvider.GetService<IUserLogic>();
+        User = userLogic.GetUserById(recipe.AuthorID);
+
+        AuthorName.BindingContext = User;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[RecipeDetailedView] (ERROR!) {ex.InnerException.Message}");
+        }
 
         //try
         //{

--- a/RecipeDetailedView.xaml.cs
+++ b/RecipeDetailedView.xaml.cs
@@ -1,4 +1,5 @@
 using CookNook.Model.Interfaces;
+using CookNook.XMLHelpers;
 
 namespace CookNook;
 using CookNook.Model;
@@ -31,16 +32,24 @@ public partial class RecipeDetailedView : ContentPage
 		InitializeComponent();
         try
         {
+		    recipe = inRecipe;
+            //BindingContext = this;
+            BindingContext = recipe;
 
-		recipe = inRecipe;
-        //BindingContext = this;
-        BindingContext = recipe;
-        Debug.WriteLine($"Viewing recipe {inRecipe.ID} by {recipe.AuthorID}");
-        //userLogic = new UserLogic(new Model.Services.UserDatabase(), new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase())));
-        userLogic = MauiProgram.ServiceProvider.GetService<IUserLogic>();
-        User = userLogic.GetUserById(recipe.AuthorID);
+            Debug.WriteLine($"Viewing recipe {inRecipe.ID} by {recipe.AuthorID}");
+            
+            //userLogic = new UserLogic(new Model.Services.UserDatabase(), new RecipeLogic(new RecipeDatabase(), new IngredientLogic(new IngredientDatabase())));
+            userLogic = MauiProgram.ServiceProvider.GetService<IUserLogic>();
+            User = userLogic.GetUserById(recipe.AuthorID);
 
-        AuthorName.BindingContext = User;
+            // since the IngredientSelector needs to be accessible for determining which DataTemplate we use for each Ingredient...
+            var templateSelector = new IngredientTemplateSelector(Resources);
+
+            // ...we define it here
+            Resources["IngredientTemplateSelector"] = templateSelector;
+
+            // bind the label for the username to the user
+            AuthorName.BindingContext = User;
         }
         catch (Exception ex)
         {
@@ -65,4 +74,18 @@ public partial class RecipeDetailedView : ContentPage
     }
 
 
+    /// <summary>
+    /// simple checker to see if the user should see the "Missing ingredients" message
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void OnIngredientsLoaded(object sender, EventArgs e)
+    {
+        // check if the recipe's ingredient list is empty
+        if (recipe.Ingredients == null || recipe.Ingredients.Count == 0)
+            MissingIngredientsLabel.IsVisible = true;
+        else 
+            MissingIngredientsLabel.IsVisible = false;
+
+    }
 }

--- a/RecipePopUpView.xaml
+++ b/RecipePopUpView.xaml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-       xmlns:converter="clr-namespace:CookNook.Model"
+       xmlns:XmlHelpers="clr-namespace:CookNook.XMLHelpers"
        x:Class="CookNook.RecipePopUpView"
        BackgroundColor="#00000000">
     <!-- Transparent background to still see the previous screen -->
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <converter:ByteToImageConverter x:Key="ByteToImageConverter"/>
+            <XmlHelpers:ByteToImageConverter x:Key="ByteToImageConverter"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/Services/IngredientDatabase.cs
+++ b/Services/IngredientDatabase.cs
@@ -178,6 +178,8 @@ namespace CookNook.Services
                 string unit = SafeGetString(reader, 2);
                 string name = reader.GetString(3);
                 
+                Debug.WriteLineIf(unit == null, $"[IngredientDB] (ERROR!) unit was not parsed safely!");
+                Debug.WriteLine($"[IngredientDB] Value of Unit: {unit}");
                 // NOTE: unit should only ever be one of the picker values, or NULL
                 Ingredient ingredient;
 
@@ -194,6 +196,10 @@ namespace CookNook.Services
                 ingredients.Add(ingredient);
             }
             reader.Close();
+            if(ingredients == null)
+            {
+                Debug.WriteLine($"[IngredientDB] (ERROR!) ingredients from recipe {recipeId}");
+            }
             return ingredients;
         }
 

--- a/Services/RecipeDatabase.cs
+++ b/Services/RecipeDatabase.cs
@@ -467,6 +467,7 @@ namespace CookNook.Services
                     {
                         // ask the ingredientDatabase for this recipes ingredints
                         var ingredients = ingredientDatabase.GetIngredientsFromRecipe(recipeID);
+
                         Recipe recipe = new Recipe
                         {
                             ID = reader.GetInt64(0),
@@ -476,7 +477,8 @@ namespace CookNook.Services
                             Course = CourseType.Parse(reader.GetString(4)),
                             Rating = reader.GetInt32(5),
                             Servings = reader.GetInt32(6),
-                            AuthorID = reader.GetInt64(8)
+                            AuthorID = reader.GetInt64(8),
+                            Ingredients = ingredients
                         };
 
                         if (!reader.IsDBNull(7))

--- a/Services/RecipeDatabase.cs
+++ b/Services/RecipeDatabase.cs
@@ -465,8 +465,8 @@ namespace CookNook.Services
                     Debug.Write(recipeID);
                     while (reader.Read())
                     {
-                        //var ingredients = GetIngredientsByRecipe(recipeID).ToArray();
-
+                        // ask the ingredientDatabase for this recipes ingredints
+                        var ingredients = ingredientDatabase.GetIngredientsFromRecipe(recipeID);
                         Recipe recipe = new Recipe
                         {
                             ID = reader.GetInt64(0),

--- a/XMLHelpers/ByteToImageConverter.cs
+++ b/XMLHelpers/ByteToImageConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.IO;
 using Microsoft.Maui.Controls;
 
-namespace CookNook.Model;
+namespace CookNook.XMLHelpers;
 
 public class ByteToImageConverter : IValueConverter
 {

--- a/XMLHelpers/IngredientTemplateSelector.cs
+++ b/XMLHelpers/IngredientTemplateSelector.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CookNook.Model;
+
+namespace CookNook.XMLHelpers
+{
+    /// <summary>
+    /// This class handles the programmatic decision of which DataTemplate to use to display a 
+    /// given Ingredient on a page (most likely in some sort of CollectionView). 
+    /// 
+    /// Ingredients will require few templates for now, but what DOES need to be handled is:
+    /// - Ingredients that would trigger an allergic reaction, per the user's dietary preferences
+    /// - "Unitless Ingredients" which do not need their unit field to be displayed 
+    /// - Standard Ingredient
+    /// </summary>
+    public class IngredientTemplateSelector : DataTemplateSelector
+    {
+        // DataTemplate repertoire 
+        public DataTemplate unitlessIngredientTemplate { get
+            {
+                // grab the DataTemplate already defined from the XAML
+                return (DataTemplate)Application.Current.Resources["UnitlessIngredientTemplate"];
+            }
+        }
+
+        public DataTemplate standardIngredientTemplate { get
+            {
+                // grab the DataTemplate already defined from the XAML
+                return (DataTemplate)Application.Current.Resources["IngredientTemplate"];
+            }
+        }
+
+        // public DataTemplate likedIngredientTemplate { get; set; }
+        // public DataTemplate dislikedIngredientTemplate { get; set; }
+        // public DataTemplate allergenIngredientTemplate { get; set; }
+
+        /// <summary>
+        /// Checks information about the incoming item, and uses the analysis to determine
+        /// which DataTemplate makes the most sense to return.
+        /// </summary>
+        /// <param name="item">The incoming Ingredient that will be checked</param>
+        /// <param name="container"></param>
+        /// <returns></returns>
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            var ingredient = item as Ingredient;
+
+            if (ingredient == null)
+                return null;
+
+            
+            // check if the item is unitless (unit is null)
+            if (string.IsNullOrEmpty(ingredient.Unit))
+            {
+                return unitlessIngredientTemplate;
+            }
+            else
+            {
+                // if the item is NOT unitless, then we can use the standard ingredient DataTemplate
+                return standardIngredientTemplate;
+            }
+            Debug.WriteLine("[IngredientTemplateSelector] (ERROR)! No template was selected!");
+            return new DataTemplate();
+        }
+    }
+}

--- a/XMLHelpers/IngredientTemplateSelector.cs
+++ b/XMLHelpers/IngredientTemplateSelector.cs
@@ -20,23 +20,17 @@ namespace CookNook.XMLHelpers
     public class IngredientTemplateSelector : DataTemplateSelector
     {
         // DataTemplate repertoire 
-        public DataTemplate unitlessIngredientTemplate { get
-            {
-                // grab the DataTemplate already defined from the XAML
-                return (DataTemplate)Application.Current.Resources["UnitlessIngredientTemplate"];
-            }
-        }
-
-        public DataTemplate standardIngredientTemplate { get
-            {
-                // grab the DataTemplate already defined from the XAML
-                return (DataTemplate)Application.Current.Resources["IngredientTemplate"];
-            }
-        }
+        // stores the ContentPage's ResourceDictionary so we have access to the necessary DataTemplates
+        private readonly ResourceDictionary resources;
 
         // public DataTemplate likedIngredientTemplate { get; set; }
         // public DataTemplate dislikedIngredientTemplate { get; set; }
         // public DataTemplate allergenIngredientTemplate { get; set; }
+
+        public IngredientTemplateSelector(ResourceDictionary pageResource)
+        {
+            resources = pageResource;
+        }
 
         /// <summary>
         /// Checks information about the incoming item, and uses the analysis to determine
@@ -56,12 +50,12 @@ namespace CookNook.XMLHelpers
             // check if the item is unitless (unit is null)
             if (string.IsNullOrEmpty(ingredient.Unit))
             {
-                return unitlessIngredientTemplate;
+                return (DataTemplate)Application.Current.Resources["UnitlessIngredientTemplate"];
             }
             else
             {
                 // if the item is NOT unitless, then we can use the standard ingredient DataTemplate
-                return standardIngredientTemplate;
+                return (DataTemplate)Application.Current.Resources["IngredientTemplate"]; ;
             }
             Debug.WriteLine("[IngredientTemplateSelector] (ERROR)! No template was selected!");
             return new DataTemplate();


### PR DESCRIPTION
Ingredients shown on the screen for viewing a full recipe instance wouldn't show actual Ingredients, just hard-coded dummy data.
This branch of work sought to make the page pull in the Ingredients from the Database services, then use an `IngredientTemplateSelector` to handle the manner of displaying the ingredient.  

In the future, we'll revisit this branch to handle conflicts with their dietary preferences